### PR TITLE
Enable AndroidX and Jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
## Summary
- Enable AndroidX and Jetifier in project-level `gradle.properties`.

## Testing
- `./gradlew clean assembleDebug` *(fails: Unable to access jarfile gradle-wrapper.jar)*
- `gradle clean assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c40439ec832ca88eb6549c7bcdc8