### PR TITLE
Add Queen branding to main screen

### DIFF
--- a/app/src/main/java/com/example/amirkalif/MainActivity.java
+++ b/app/src/main/java/com/example/amirkalif/MainActivity.java
@@ -22,6 +22,10 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().hide();
+        }
+
         imgPhoto = findViewById(R.id.imgPhoto);
         tvName = findViewById(R.id.tvName);
         lstMusician = findViewById(R.id.lstMusician);

--- a/app/src/main/java/com/example/amirkalif/SplashActivity.java
+++ b/app/src/main/java/com/example/amirkalif/SplashActivity.java
@@ -16,6 +16,10 @@ public class SplashActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_splash);
 
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().hide();
+        }
+
         Button btnEnter = findViewById(R.id.btnEnter);
         btnEnter.setOnClickListener(v -> {
             startActivity(new Intent(SplashActivity.this, MainActivity.class));

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,6 +5,28 @@
     android:layout_height="match_parent"
     android:padding="16dp">
 
+    <TextView
+        android:id="@+id/tvHeader"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/queen_header"
+        android:textSize="28sp"
+        android:textStyle="bold"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <ImageView
+        android:id="@+id/imgLogo"
+        android:layout_width="150dp"
+        android:layout_height="150dp"
+        android:contentDescription="@string/queen_logo_desc"
+        android:src="@drawable/queen_logo"
+        android:layout_marginTop="16dp"
+        app:layout_constraintTop_toBottomOf="@id/tvHeader"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
     <ImageView
         android:id="@+id/imgPhoto"
         android:layout_width="150dp"
@@ -12,7 +34,8 @@
         android:contentDescription="@string/selected_member_photo"
         android:scaleType="centerCrop"
         android:src="@drawable/placeholder"
-        app:layout_constraintTop_toTopOf="parent"
+        android:layout_marginTop="16dp"
+        app:layout_constraintTop_toBottomOf="@id/imgLogo"
         app:layout_constraintStart_toStartOf="parent" />
 
     <TextView
@@ -23,7 +46,6 @@
         android:textSize="20sp"
         android:textStyle="bold"
         android:padding="8dp"
-        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toEndOf="@id/imgPhoto"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintBaseline_toBaselineOf="@id/imgPhoto" />

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -16,18 +16,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
-    <TextView
-        android:id="@+id/tvStudentName"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/student_name"
-        android:textSize="24sp"
-        android:textStyle="bold"
-        android:layout_marginTop="20dp"
-        app:layout_constraintTop_toBottomOf="@id/imgSplashLogo"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
-
     <Button
         android:id="@+id/btnEnter"
         android:layout_width="wrap_content"
@@ -37,7 +25,8 @@
         android:paddingRight="24dp"
         android:paddingTop="12dp"
         android:paddingBottom="12dp"
-        app:layout_constraintTop_toBottomOf="@id/tvStudentName"
+        android:layout_marginTop="20dp"
+        app:layout_constraintTop_toBottomOf="@id/imgSplashLogo"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">AmirKalif</string>
-    <string name="student_name">Amir Kalif</string>
+    <string name="app_name">Queen</string>
     <string name="enter_button_text">Enter</string>
     <string name="queen_logo_desc">Queen Logo</string>
     <string name="member_photo">Member Photo</string>
     <string name="selected_member_photo">Selected Member Photo</string>
     <string name="choose_member">Select a member</string>
+    <string name="queen_header">QUEEN</string>
 </resources>


### PR DESCRIPTION
## Summary
- Display bold "QUEEN" header and logo on main screen
- Remove student name from splash screen and hide default action bars
- Rename app to "Queen"

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ef801318832c9fdd394195af9eb4