### PR TITLE
Center selected name and shift list below

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -50,15 +50,16 @@
 
     <TextView
         android:id="@+id/tvName"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
         android:text="@string/choose_member"
         android:textSize="20sp"
         android:textStyle="bold"
         android:padding="8dp"
-        app:layout_constraintStart_toEndOf="@id/imgPhoto"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBaseline_toBaselineOf="@id/imgPhoto" />
+        app:layout_constraintTop_toBottomOf="@id/imgPhoto"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
     <ListView
         android:id="@+id/lstMusician"
@@ -66,7 +67,7 @@
         android:layout_height="0dp"
         android:dividerHeight="1dp"
         android:layout_marginTop="16dp"
-        app:layout_constraintTop_toBottomOf="@id/imgPhoto"
+        app:layout_constraintTop_toBottomOf="@id/tvName"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />


### PR DESCRIPTION
## Summary
- Center the selected musician name under the photo and add top margin
- Position the musician list beneath the name to move it further down

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a80cab9fbc832cb166614a05a23ede